### PR TITLE
Replace manual thread creation with ExecutorService threadpool

### DIFF
--- a/src/main/java/lab1/recipe06/Main.java
+++ b/src/main/java/lab1/recipe06/Main.java
@@ -2,18 +2,24 @@ package lab1.recipe06;
 
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class Main {
-    public static void main(String[] args){
+    public static void main(String[] args) {
         Deque<Event> deque = new ConcurrentLinkedDeque<>();
 
         WriterTask writer = new WriterTask(deque);
 
-        for(int i = 0; i  < Runtime.getRuntime().availableProcessors(); i++){
-            Thread thread = new Thread(writer);
-            thread.start();
+        ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() + 1);
+
+        for (int i = 0; i < Runtime.getRuntime().availableProcessors(); i++) {
+            executorService.submit(writer);
         }
+
         CleanerTask cleaner = new CleanerTask(deque);
-        cleaner.start();
+        executorService.submit(cleaner);
+
+        executorService.shutdown();
     }
 }


### PR DESCRIPTION
## Issue #16  👍  Use Thread Pools in recipe 06 :

### Replaced Manual Thread Creation with a Thread Pool

In `Main.java`, the manual creation of threads using `new Thread(writer)` and `cleaner.start()` has been replaced with an `ExecutorService` thread pool.

The thread pool is created using `Executors.newFixedThreadPool()` with a size equal to the number of available processors plus one (to accommodate the `CleanerTask`).

### Tasks Submitted to the Thread Pool

- The `WriterTask` instances are submitted to the thread pool using `executorService.submit(writer)`.
- The `CleanerTask` is also submitted to the thread pool using `executorService.submit(cleaner)`.

### Graceful Shutdown

The `executorService.shutdown()` method is called to ensure the thread pool shuts down gracefully after all tasks are submitted.